### PR TITLE
fix: API security hardening and stability improvements

### DIFF
--- a/src/WinBGP-API.ps1
+++ b/src/WinBGP-API.ps1
@@ -141,13 +141,18 @@ function Write-Log {
           if ($AdditionalFields) {
             $EventInstance = [System.Diagnostics.EventInstance]::new($EventLogId, $EventLogCategory, $Level)
             $NewEvent = [System.Diagnostics.EventLog]::new()
-            $NewEvent.Log = $EventLogName
-            $NewEvent.Source = $EventLogSource
-            [Array] $JoinedMessage = @(
-            $Message
-            $AdditionalFields | ForEach-Object { $_ }
-            )
-            $NewEvent.WriteEvent($EventInstance, $JoinedMessage)
+            # FIX 1.1: EventLog implements IDisposable - use try/finally to prevent handle leak in long-running service
+            try {
+              $NewEvent.Log = $EventLogName
+              $NewEvent.Source = $EventLogSource
+              [Array] $JoinedMessage = @(
+              $Message
+              $AdditionalFields | ForEach-Object { $_ }
+              )
+              $NewEvent.WriteEvent($EventInstance, $JoinedMessage)
+            } finally {
+              $NewEvent.Dispose()
+            }
           } else {
             #Write log to event viewer (Enabled by default)
             Write-EventLog -LogName $EventLogName -Source $EventLogSource -EventId $EventLogId -EntryType $Level -Category $EventLogCategory -Message "$Message"
@@ -328,6 +333,9 @@ if ($Configuration) {
             Write-Log -Message "API started - Listening on '$($IP):$($Port)' (Protocol: $Protocol)"
         }
         
+        # FIX 1.3: Wrap listener lifecycle in try/finally to ensure HttpListener is always stopped/closed,
+        # even if an unhandled exception occurs inside the request processing loop
+        try {
         while (($listener.IsListening) -and ($keepListening)) {
             # Default return
             $statusCode = [System.Net.HttpStatusCode]::OK
@@ -358,6 +366,9 @@ if ($Configuration) {
             
             # If local, we don't support authentication for now (TO IMPROVE)
             if ($request.IsLocal -or $Authenticated) {
+              # FIX 3.5: Wrap request processing in try/catch so a single failed request
+              # doesn't crash the entire API listener (e.g. ConvertTo-Json or Get-BgpPeer error)
+              try {
                 # Log every api request
                 # [string]$FullRequest = $request | Format-List * | Out-String
                 # Write-Log "API request received: $FullRequest" -EventLogSource 'WinBGP-API'
@@ -514,6 +525,13 @@ if ($Configuration) {
                         }
                         elseif ($FullPath -like 'api/*') {
                             $RouteName = $request.QueryString.Item("RouteName")
+                            # FIX 2.2: Validate RouteName input to prevent injection via API query strings
+                            # Only allow alphanumeric characters, hyphens, underscores and dots
+                            if ($RouteName -and $RouteName -notmatch '^[a-zA-Z0-9_\-\.]+$') {
+                                Write-Log "API rejected invalid RouteName '$RouteName' from '$RequestHost'" -Level Warning
+                                $statusCode = [System.Net.HttpStatusCode]::BadRequest
+                                $commandOutput = ConvertTo-Json -InputObject @{'error'='Invalid RouteName parameter'}
+                            } else {
                             $Path=$Path.replace('api/','')
                             Write-Log "API received POST request '$Path' from '$RequestUser' - Source IP: '$RequestHost'" -AdditionalFields $RouteName
                             switch ($Path) {
@@ -550,6 +568,7 @@ if ($Configuration) {
                                 'Success' { $statusCode = [System.Net.HttpStatusCode]::OK }
                                 'WinBGP not ready' { $statusCode = [System.Net.HttpStatusCode]::InternalServerError }
                             }
+                            } # End of RouteName validation else block
                         } else {
                             $statusCode = [System.Net.HttpStatusCode]::NotImplemented
                         }
@@ -558,6 +577,12 @@ if ($Configuration) {
                         $statusCode = [System.Net.HttpStatusCode]::NotImplemented
                     }
                 }
+              } catch {
+                # FIX 3.5: Catch request processing errors - log and return 500 instead of crashing the listener
+                Write-Log "API request processing error: $_" -Level Error
+                $statusCode = [System.Net.HttpStatusCode]::InternalServerError
+                $commandOutput = ConvertTo-Json -InputObject @{'error'='Internal server error'}
+              }
             }
             $response = $context.Response
             $response.StatusCode = $statusCode
@@ -574,8 +599,11 @@ if ($Configuration) {
             $output.Write($buffer,0,$buffer.Length)
             $output.Close()
         }
-        if ($listener.IsListening) {
-            $listener.Stop()
+        } finally {
+            # FIX 1.3: Ensure HttpListener is always cleaned up, even on unhandled exception
+            if ($listener.IsListening) {
+                $listener.Stop()
+            }
             $listener.Close()
         }
     } else {


### PR DESCRIPTION
## Summary

This PR improves the WinBGP API security and stability with 4 changes:

### Changes

1. **Input validation on RouteName** (Security)
   - Reject API query string `RouteName` containing non-alphanumeric characters (`;`, `|`, `'`, spaces, etc.)
   - Returns HTTP 400 Bad Request with a warning logged to Event Log
   - Prevents potential injection when RouteName is passed to WinBGP cmdlets

2. **Request processing try/catch** (Stability)
   - Wrap all GET/POST request processing in try/catch
   - A single failed request (e.g. ConvertTo-Json error, Get-BgpPeer timeout) no longer crashes the entire API listener
   - Returns HTTP 500 Internal Server Error instead of killing the listener

3. **HttpListener try/finally** (Resource leak)
   - Ensure `$listener.Stop()` and `$listener.Close()` are always called, even on unhandled exception
   - Prevents the listening port from remaining blocked after a crash

4. **EventLog Dispose** (Memory leak)
   - `[System.Diagnostics.EventLog]::new()` in Write-Log with AdditionalFields was never disposed
   - Added try/finally with `$NewEvent.Dispose()` to prevent handle exhaustion in long-running service

### Test Results

Tested on proper server (WinBGP service running, 3 active routes):

| Test | Description | Expected | Result |
|------|-------------|----------|--------|
| 1a | `RouteName=test;evil` | 400 | ✅ 400 |
| 1b | `RouteName=test\|whoami` | 400 | ✅ 400 |
| 1c | `RouteName=test'drop` | 400 | ✅ 400 |
| 1d | Valid RouteName (dots, hyphens) | 200 | ✅ 200 |
| 2 | GET /api/nonexistent | 501, API still running | ✅ |
| 3 | Event Log | Warnings logged for rejected requests | ✅ |
| 4 | GET /api/routes | Returns 3 routes | ✅ |
| 5 | GET /metrics | Prometheus metrics returned | ✅ |

### Event Log evidence from winbgp -logs

17/06/2026 07:56:36 Warning API rejected invalid RouteName 'test'drop' from '127.0.0.1'
17/06/2026 07:56:30 Warning API rejected invalid RouteName 'test|whoami' from '127.0.0.1'
17/06/2026 07:56:15 Warning API rejected invalid RouteName 'test;evil' from '127.0.0.1'

### Files changed

- `src/WinBGP-API.ps1`