### PR TITLE
fix: add -UseBasicParsing to Stop-API Invoke-WebRequest

### DIFF
--- a/src/WinBGP-Engine.ps1
+++ b/src/WinBGP-Engine.ps1
@@ -984,9 +984,10 @@ function Start-API() {
 function Stop-API() {
   # Stop API
   Write-Log "Stopping API engine"
-  # Send API stop signal (TO IMPROVE)
+  # Send API stop signal
   try {
-    if ((Invoke-WebRequest -Uri 'http://127.0.0.1:8888/stop' -Method Post -TimeoutSec 5).StatusCode -eq 200) {
+    # FIX: Added -UseBasicParsing to avoid dependency on Internet Explorer engine (not available on Server Core / SYSTEM account)
+    if ((Invoke-WebRequest -Uri 'http://127.0.0.1:8888/stop' -Method Post -TimeoutSec 5 -UseBasicParsing).StatusCode -eq 200) {
       Stop-Job -Name 'API' -ErrorAction SilentlyContinue
       Remove-Job -Name 'API' -Force -ErrorAction SilentlyContinue
     }


### PR DESCRIPTION
## Summary

Fix `Stop-API` function failing on Windows Server when Internet Explorer is not available or not initialized (Server Core, SYSTEM account).

### Problem

When the WinBGP engine tries to stop the API via `Invoke-WebRequest`, it fails because the cmdlet attempts to use the IE COM engine (`mshtml.dll`) for HTML parsing by default in PowerShell 5.1. This produces the following error:

Error stopping API engine: The response content cannot be parsed because the Internet Explorer
engine is not available, or Internet Explorer's first-launch configuration is not complete.
Specify the UseBasicParsing parameter and try again.

This caused the API stop to silently fail, leaving the port blocked and requiring the Watchdog to restart the API (with port conflict errors in the logs).

### Fix

Added `-UseBasicParsing` to the `Invoke-WebRequest` call in `Stop-API()`. This parameter bypasses the IE dependency and works in all contexts (SYSTEM account, Server Core, PowerShell 5.1).

### Files changed

- `src/WinBGP-Engine.ps1` (1 line changed)

### Test Results

Tested on local server:

| Test | Command | Expected | Result |
|------|---------|----------|--------|
| 1 | `WinBGP -RestartAPI` | No IE error in Event Log | ✅ |
| 2 | Event Log after restart | Clean stop/start cycle | ✅ |
| 3 | `Invoke-RestMethod http://127.0.0.1:8888/api` | API running | ✅ |

### Event Log evidence (after fix)
17/06/2026 09:55:32 Information API started - Listening on '127.0.0.1:8888' (Protocol: http)
17/06/2026 09:55:32 Information API started - Listening on 'ip:8888' (Protocol: https)
17/06/2026 09:55:27 Information Starting API engine
17/06/2026 09:55:27 Information Stopping API engine ← No IE error ✅
17/06/2026 09:55:27 Information Restarting API engine

