### PR TITLE
fix: EventLog handle leak and StreamWriter crash in WinBGP CLI

### DIFF
--- a/src/WinBGP.ps1
+++ b/src/WinBGP.ps1
@@ -313,13 +313,18 @@ function Write-Log {
         if ($AdditionalFields) {
           $EventInstance = [System.Diagnostics.EventInstance]::new($EventLogId, $EventLogCategory, $Level)
           $NewEvent = [System.Diagnostics.EventLog]::new()
-          $NewEvent.Log = $EventLogName
-          $NewEvent.Source = $EventLogSource
-          [Array] $JoinedMessage = @(
-          $Message
-          $AdditionalFields | ForEach-Object { $_ }
-          )
-          $NewEvent.WriteEvent($EventInstance, $JoinedMessage)
+          # FIX 1.1: EventLog implements IDisposable - use try/finally to prevent handle leak in long-running service
+          try {
+            $NewEvent.Log = $EventLogName
+            $NewEvent.Source = $EventLogSource
+            [Array] $JoinedMessage = @(
+            $Message
+            $AdditionalFields | ForEach-Object { $_ }
+            )
+            $NewEvent.WriteEvent($EventInstance, $JoinedMessage)
+          } finally {
+            $NewEvent.Dispose()
+          }
         } else {
           #Write log to event viewer (Enabled by default)
           Write-EventLog -LogName $EventLogName -Source $EventLogSource -EventId $EventLogId -EntryType $Level -Category $EventLogCategory -Message "$Message"
@@ -359,11 +364,12 @@ Function Send-PipeMessage () {
   $sw = $null   # Stream Writer
   try {
     $pipe = new-object System.IO.Pipes.NamedPipeClientStream(".", $PipeName, $PipeDir, $PipeOpt)
-    $sw = new-object System.IO.StreamWriter($pipe)
+    # FIX: StreamWriter created after Connect() to avoid Dispose() crash on unconnected pipe
     $pipe.Connect(1000)
     if (!$pipe.IsConnected) {
       throw "Failed to connect client to pipe $pipeName"
     }
+    $sw = new-object System.IO.StreamWriter($pipe)
     $sw.AutoFlush = $true
     $sw.WriteLine($Message)
   } catch {


### PR DESCRIPTION
## Summary

Fix two resource management issues in `WinBGP.ps1` (CLI):

### 1. EventLog handle leak in Write-Log
`[System.Diagnostics.EventLog]::new()` implements `IDisposable` but was never disposed after writing events with `AdditionalFields`. In a 24/7 service context, this causes gradual handle exhaustion.

**Fix:** Wrap EventLog usage in `try/finally` with `Dispose()`.

### 2. StreamWriter crash on unconnected pipe in Send-PipeMessage
`StreamWriter` was created before `pipe.Connect()`. If the connection failed or timed out, `Dispose()` on the `StreamWriter` would throw an unhandled .NET exception because the underlying pipe was never connected.

**Fix:** Move `StreamWriter` creation after successful `pipe.Connect(1000)`.

## Testing

Tested on production server `my.server.net`.

### Functional tests
| Command | Result |
|---------|--------|
| `WinBGP.ps1 -Status` | ✅ `Running` |
| `WinBGP.ps1 -BGPStatus` | ✅ 3 routes displayed (route1, route2, route3) all `up` |
| `WinBGP.ps1 -RouteName my.server.net -StartMaintenance` | ✅ `Success` |
| `WinBGP.ps1 -RouteName my.server.net -StopMaintenance` | ✅ `Success` |
| `WinBGP.ps1 -RouteName my.server.net -StopRoute` | ✅ `Success` |
| `WinBGP.ps1 -RouteName my.server.net -StartRoute` | ✅ `Success` |

### Handle leak test

```powershell
$svcPid = (Get-CimInstance Win32_Service -Filter "Name='WinBGP'").ProcessId
Get-Process -Id $svcPid | Select-Object HandleCount
1..50 | ForEach-Object { & "C:\Program Files\WinBGP\WinBGP.ps1" -Status }
Get-Process -Id $svcPid | Select-Object HandleCount
```

| Metric | Value |
|--------|-------|
| HandleCount before (PID 1264) | **214** |
| 50x consecutive `-Status` calls | All returned `Running` |
| HandleCount after | **214** |
| **Result** | ✅ No handle leak |

